### PR TITLE
Modified luftboot to work with current paparazzi-arm-multilib on linux

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -4,6 +4,8 @@ OBJCOPY = $(CROSS_COMPILE)objcopy
 TOOLCHAIN_DIR=$(shell dirname `which arm-none-eabi-gcc`)
 ifeq ($(TOOLCHAIN_DIR),)
 TOOLCHAIN_DIR=$(shell find -L /opt/paparazzi/arm-multilib ~/sat /opt/paparazzi/stm32 -maxdepth 1 -type d -name arm-none-eabi 2>/dev/null | head -n 1)
+CC = $(TOOLCHAIN_DIR)/../bin/$(CROSS_COMPILE)gcc
+OBJCOPY = $(TOOLCHAIN_DIR)/../bin/$(CROSS_COMPILE)objcopy
 endif
 
 LIBOPENCM3 ?= $(TOOLCHAIN_DIR)/..
@@ -16,9 +18,9 @@ VERSION = V1.0
 DEV_SERIAL = NSERIAL
 
 CFLAGS += -Os -g3 -Istm32/include -mcpu=cortex-m3 -mthumb -msoft-float -DSTM32F1 -I$(LIBOPENCM3)/include --function-sections --data-sections -DVERSION="\"$(VERSION)\"" -DDEV_SERIAL="\"$(DEV_SERIAL)\""
-LDFLAGS_BOOT = -lopencm3_stm32f1 -Wl,--defsym,_stack=0x20005000 \
+LDFLAGS_BOOT = -lopencm3_stm32 -Wl,--defsym,_stack=0x20005000 \
 	-Wl,-T,luftboot.ld -nostartfiles -lc -lnosys -Wl,-Map=mapfile \
-	-mthumb -march=armv7 -mcpu=cortex-m3 -mfix-cortex-m3-ldrd -msoft-float -L$(LIBOPENCM3)/lib/stm32/f1 -Wl,--gc-sections
+	-mthumb -march=armv7 -mcpu=cortex-m3 -mfix-cortex-m3-ldrd -msoft-float -L$(LIBOPENCM3)/lib/stm32 -Wl,--gc-sections
 LDFLAGS_BOOT += -Wl,--section-start=.devserial=0x8001FF0
 LDFLAGS = $(LDFLAGS_BOOT) -Wl,-Ttext=0x8002000
 

--- a/src/luftboot.c
+++ b/src/luftboot.c
@@ -20,10 +20,10 @@
 
 #include <string.h>
 #include <libopencm3/stm32/systick.h>
-#include <libopencm3/stm32/f1/rcc.h>
-#include <libopencm3/stm32/f1/gpio.h>
-#include <libopencm3/stm32/f1/flash.h>
-#include <libopencm3/stm32/f1/scb.h>
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/flash.h>
+#include <libopencm3/stm32/scb.h>
 #include <libopencm3/usb/usbd.h>
 #include <libopencm3/usb/dfu.h>
 

--- a/src/luftboot.ld
+++ b/src/luftboot.ld
@@ -25,5 +25,5 @@ MEMORY
 }
 
 /* Include the common ld script from libopenstm32. */
-INCLUDE libopencm3_stm32f1.ld
+INCLUDE libopencm3_stm32.ld
 


### PR DESCRIPTION
Just modified the makefile & source to compile on my system.
The modifications may or may not be correct.
Cheers,
Gareth

```
$ cat /etc/apt/sources.list | grep paparazzi
deb http://paparazzi.enac.fr/ubuntu oneiric main

$ apt-cache show paparazzi-arm-multilib 
Package: paparazzi-arm-multilib
Version: 1.0.0-1

$ uname -r
3.0.0-1-686-pae

$ cat /etc/lsb-release 
DISTRIB_ID=LinuxMint
DISTRIB_RELEASE=1
DISTRIB_CODENAME=debian
DISTRIB_DESCRIPTION="Linux Mint Debian Edition"
```
