### PR TITLE
changed behaviour of luftboot to better match LPC21xx bootloader

### DIFF
--- a/README
+++ b/README
@@ -5,3 +5,18 @@ autopilot firmware using usb. It implements the dfu standard.
 
 Luftboot is based on the usbdfu bootloader implementation by Gareth McMullin
 for the Black Magic Probe project (http://www.blacksphere.co.nz/main/blackmagic).
+
+By default, Luftboot uses a 12MHz external clock to PLL it to 72MHz. If no external
+clock is available, or for any other reason, one can build Luftboot to use the 8MHz
+internal RC oscillator to PLL it to 48MHz. Call make as follows from inside ./src:
+    make LUFTBOOT_USE_48MHZ_INTERNAL_OSC=1
+
+At bootup, Luftboot uses several criteria (in this order) to decide whether to jump
+to the payload or to initiate the bootloader:
+ * On boot, if the payload is NOT valid, start the bootloader
+ * If the flag is set indicating we just downloaded a payload, jump to payload
+ * If the payload is forcing the bootloader (using GPIO state after core-only reset)
+   start the bootloader
+ * If the ADC2 pin on Lisa/M is grounded, jump to payload (i.e. "skip bootloader" jumper)
+ * If voltage is present on the USB vbus, start the bootloader
+ * Otherwise, jump to payload

--- a/src/Makefile
+++ b/src/Makefile
@@ -36,6 +36,10 @@ else
 LDFLAGS_BOOT += -Wl,--print-gc-sections
 endif
 
+ifeq ($(LUFTBOOT_USE_48MHZ_INTERNAL_OSC),1)
+CFLAGS += -DLUFTBOOT_USE_48MHZ_INTERNAL_OSC=1
+endif
+
 all: luftboot.bin luftboot.hex
 
 luftboot: luftboot.o


### PR DESCRIPTION
- thanks to @softsr (sergey krukowski) for starting the work
- after payload upload, set flag and reset device
- on boot, if upload just occurred, clear flag and jump to payload
- if payload forced bootloader, start bootloader
- if skip bootloader pin grounded, jump to payload
- if USB vbus powered, start bootloader
- otherwise, jump to payload

Either the external clock (12MHz PLL to 72MHz) or internal oscillator
(8MHz PLL to 48MHz) can be selected at build time. See README.

@softsr, after some consideration, I think your method of setting a flag to allow a full reset is a better solution. I added several features and a few extra comments. Regarding the clock selection, really the external clock should be more stable and reliable, especially for timing sensitive USB operation. However, one can now select internal vs external clock at build time (the default is still external). Any thoughts?

@esden, could you take a quick look?
